### PR TITLE
Add option to filter out warnings from errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "medic-conf-test-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medic-conf-test-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Test Framework for Medic Projects",
   "main": "./src/harness.js",
   "scripts": {

--- a/src/form-host/wireup.js
+++ b/src/form-host/wireup.js
@@ -108,15 +108,10 @@ const bindJsonToXml = function(elem, data={}, childMatcher) {
 
 const findCurrentElement = function(elem, name, childMatcher) {
   if (childMatcher) {
-    const found = elem.find(childMatcher(name));
-    if (found.length > 1) {
-      console.warn('Using the matcher "' + childMatcher(name) + '" we found ' + found.length + ' elements, ' +
-        'we should only ever bind one.', elem);
-    }
-    return found;
-  } else {
-    return elem.children(name);
-  }
+    return elem.find(childMatcher(name));
+  } 
+  
+  return elem.children(name);
 };
 
 module.exports = FormWireup;


### PR DESCRIPTION
Resolves #88

How to use:

```js
const TestHarness = require('medic-conf-test-harness');
const harness = new TestHarness({
    excludeWarningsFromConsoleErrors: true
})
```

If you have this in your tests:

```js
afterEach(() => {
    var errors = harness.consoleErrors.filter(error => {
        return error._type !== 'warning';
    });
    expect(errors).to.be.empty;
});
```

You can change it to

```js
 afterEach(() => expect(harness.consoleErrors).to.be.empty );
```

Questions:
- What would be the most appropriate option name?
- Is this even useful? 